### PR TITLE
✨feat: 유저 관련 CRUD 기능 개발

### DIFF
--- a/src/main/java/com/likelion/byuldajul/exception/ConflictException.java
+++ b/src/main/java/com/likelion/byuldajul/exception/ConflictException.java
@@ -1,0 +1,8 @@
+package com.likelion.byuldajul.exception;
+
+public class ConflictException extends RuntimeException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion/byuldajul/exception/ErrorResponse.java
+++ b/src/main/java/com/likelion/byuldajul/exception/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.likelion.byuldajul.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ErrorResponse {
+
+    private String error;
+
+    private String message;
+
+    @Builder
+    public ErrorResponse(String error, String message) {
+        this.error = error;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/likelion/byuldajul/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/byuldajul/exception/GlobalExceptionHandler.java
@@ -1,0 +1,59 @@
+package com.likelion.byuldajul.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    //400 Bad Request
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        // ErrorResponse 객체 생성
+        ErrorResponse errorResponse = new ErrorResponse("Bad Request", e.getMessage());
+        // ResponseEntity 객체를 생성하여 반환 (응답 본문: errorResponse, HTTP 상태 코드: 400)
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    //404 Not Found
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ErrorResponse> handleNoSuchElementException(NoSuchElementException e) {
+        // ErrorResponse 객체 생성
+        ErrorResponse errorResponse = new ErrorResponse("Not Found", e.getMessage());
+        // ResponseEntity 객체를 생성하여 반환 (응답 본문: errorResponse, HTTP 상태 코드: 404)
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    //409 Conflict
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ErrorResponse> handleConflictException(ConflictException e) {
+        // ErrorResponse 객체 생성
+        ErrorResponse errorResponse = new ErrorResponse("Conflict", e.getMessage());
+        // ResponseEntity 객체를 생성하여 반환 (응답 본문: errorResponse, HTTP 상태 코드: 409)
+        return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+    }
+
+    //컨트롤러 메서드에서 @Valid 어노테이션을 사용하여 DTO의 유효성 검사를 수행
+    //유효성 검사에 실패하면 MethodArgumentNotValidException 예외가 발생 -> GlobalExceptionHandler에서 예외처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        // 유효성 검사 실패한 필드와 메시지를 맵에 저장
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : e.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+        // ErrorResponse 객체 생성
+        ErrorResponse errorResponse = new ErrorResponse("Validation Failed", errors.toString());
+        // ResponseEntity 객체를 생성하여 반환 (응답 본문: errorResponse, HTTP 상태 코드: 400)
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/java/com/likelion/byuldajul/user/controller/UserController.java
+++ b/src/main/java/com/likelion/byuldajul/user/controller/UserController.java
@@ -27,149 +27,38 @@ public class UserController {
 
     //회원가입
     @PostMapping(value = "/signup")
-    public ResponseEntity<?> createUser(@Valid @RequestBody CreateUserRequestDto createUserRequestDto, BindingResult bindingResult) {
-        // 유효성 검사 결과 확인
-        if (bindingResult.hasErrors()) {
-            // 유효성 검사 실패 시
-            Map<String, String> errorMap = new HashMap<>();
-            for (FieldError error : bindingResult.getFieldErrors()) {
-                errorMap.put(error.getField(), error.getDefaultMessage());
-            }
-            // 실패 메시지와 함께 BadRequest 응답 반환
-            return ResponseEntity.badRequest().body(errorMap);
-        }
-
-        // 유효성 검사 통과 시 회원 가입 서비스 호출
-        try {
-            CreateUserResponseDto createUserResponseDto = userService.signUp(createUserRequestDto);
-            return ResponseEntity.status(HttpStatus.CREATED).body(createUserResponseDto);
-        } catch (IllegalArgumentException e) { //서비스 단에서 IllegalArgumentException 예외 catch
-            if (e.getMessage().contains("해당 이메일이 이미 존재합니다.")) { //예외 메세지에 해당 내용이 존재하면 아래 에러 응답
-                return ResponseEntity.status(HttpStatus.CONFLICT).body(
-                        Map.of("error", "Conflict",
-                                "message", e.getMessage())
-                );
-            } else { //존재하지 않으면 아래 에러 응답
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-                        Map.of("error", "Bad Request",
-                                "message", "올바르지 않은 요청입니다.")
-                );
-            }
-        }
+    public ResponseEntity<?> createUser(@Valid @RequestBody CreateUserRequestDto createUserRequestDto) {
+        CreateUserResponseDto createUserResponseDto = userService.signUp(createUserRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createUserResponseDto);
     }
 
     //회원정보 조회
     @GetMapping
     public ResponseEntity<?> getUsers(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        //인증되지 않은 경우
-        if(userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body( //UNAUTHORIZED 상태 코드와 함게 아래 key value 형태로 body값 반환
-                    Map.of("error", "Unauthorized",
-                            "message", "인증 자격 증명이 제공되지 않았거나 유효하지 않습니다.")
-            );
-        }
-
-        try {
-            //userDetails에서 getUsername 메서드로 email을 꺼내서 서비스단에서 getUserByEmail 메서드로 유저 정보를 가져옴.
-            UserResponseDto userResponseDto = userService.getUserByEmail(userDetails.getUsername());
-            return ResponseEntity.ok(userResponseDto);
-        } catch (IllegalArgumentException e) {
-            //서비스 단에서 IllegalArgumentException 예외 catch
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    Map.of("error", "Not Found",
-                            "message", e.getMessage())
-            );
-        }
+        UserResponseDto userResponseDto = userService.getUserByEmail(userDetails.getUsername());
+        return ResponseEntity.ok(userResponseDto);
     }
 
     //닉네임 변경
     @PatchMapping(value = "/nickname")
     public ResponseEntity<?> updateNickname(@AuthenticationPrincipal CustomUserDetails userDetails,
                                             @Valid @RequestBody UpdateNicknameRequestDto updateNicknameRequestDto) {
-        if (userDetails == null) {
-            // 인증되지 않은 경우
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
-                    Map.of("error", "Unauthorized",
-                            "message", "인증 자격 증명이 제공되지 않았거나 유효하지 않습니다.")
-            );
-        }
-
-        try {
-            userService.updateNickname(userDetails.getUsername(), updateNicknameRequestDto.getNickname());
-            return ResponseEntity.ok(Map.of("message", "닉네임이 성공적으로 변경되었습니다."));
-        } catch (IllegalArgumentException e) { //서비스 단에서 IllegalArgumentException 예외 catch
-            if (e.getMessage().contains("사용자가 존재하지 않습니다")) {  //예외 메세지에 해당 내용이 존재하면 아래 에러 응답
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                        Map.of("error", "Not Found",
-                                "message", e.getMessage())
-                );
-            } else { //존재하지 않으면 아래 에러 응답
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-                        Map.of("error", "Bad Request",
-                                "message", "올바르지 않은 요청입니다.")
-                );
-            }
-        }
+        userService.updateNickname(userDetails.getUsername(), updateNicknameRequestDto.getNickname());
+        return ResponseEntity.ok(Map.of("message", "닉네임이 성공적으로 변경되었습니다."));
     }
 
     //비밀번호 변경
     @PutMapping(value = "/pw")
     public ResponseEntity<?> updatePassword(@AuthenticationPrincipal CustomUserDetails userDetails,
                                             @Valid @RequestBody UpdatePasswordRequestDto updatePasswordRequestDto) {
-        if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
-                    Map.of("error", "Unauthorized",
-                            "message", "인증 자격 증명이 제공되지 않았거나 유효하지 않습니다.")
-            );
-        }
-
-        try {
-            userService.updatePassword(userDetails.getUsername(), updatePasswordRequestDto.getNewPassword());
-            return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 재설정되었습니다."));
-        } catch (IllegalArgumentException e) { //서비스 단에서 IllegalArgumentException 예외 catch
-            if (e.getMessage().contains("요청한 사용자를 찾을 수 없습니다")) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                        Map.of("error", "Not Found",
-                                "message", e.getMessage())
-                );
-            } else {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-                        Map.of("error", "Bad Request",
-                                "message", "올바르지 않은 요청입니다.")
-                );
-            }
-        }
+        userService.updatePassword(userDetails.getUsername(), updatePasswordRequestDto.getNewPassword());
+        return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 재설정되었습니다."));
     }
-
 
     //회원 탈퇴
     @DeleteMapping
     public ResponseEntity<?> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        if (userDetails == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
-                    Map.of("error", "Unauthorized",
-                            "message", "인증 자격 증명이 제공되지 않았거나 유효하지 않습니다.")
-            );
-        }
-
-        try {
-            userService.deleteUser(userDetails.getUsername());
-            return ResponseEntity.ok(Map.of("message", "사용자가 성공적으로 삭제되었습니다"));
-        } catch (IllegalArgumentException e) { //서비스 단에서 IllegalArgumentException 예외 catch
-            if (e.getMessage().contains("요청한 사용자를 찾을 수 없습니다")) {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                        Map.of("error", "Not Found",
-                                "message", e.getMessage())
-                );
-            } else {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
-                        Map.of("error", "Bad Request",
-                                "message", "올바르지 않은 요청입니다.")
-                );
-            }
-        }
+        userService.deleteUser(userDetails.getUsername());
+        return ResponseEntity.ok(Map.of("message", "사용자가 성공적으로 삭제되었습니다"));
     }
-
 }
-
-

--- a/src/main/java/com/likelion/byuldajul/user/controller/UserController.java
+++ b/src/main/java/com/likelion/byuldajul/user/controller/UserController.java
@@ -1,19 +1,18 @@
 package com.likelion.byuldajul.user.controller;
 
-import com.likelion.byuldajul.user.dto.CreateUserRequestDto;
-import com.likelion.byuldajul.user.dto.CreateUserResponseDto;
+import com.likelion.byuldajul.user.dto.*;
 import com.likelion.byuldajul.user.service.UserService;
+import com.likelion.byuldajul.user.userDetails.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,6 +25,7 @@ public class UserController {
 
     private final UserService userService;
 
+    //회원가입
     @PostMapping(value = "/signup")
     public ResponseEntity<?> createUser(@Valid @RequestBody CreateUserRequestDto createUserRequestDto, BindingResult bindingResult) {
         // 유효성 검사 결과 확인
@@ -40,7 +40,136 @@ public class UserController {
         }
 
         // 유효성 검사 통과 시 회원 가입 서비스 호출
-        CreateUserResponseDto createUserResponseDto = userService.signUp(createUserRequestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createUserResponseDto); // 생성 성공 시 Status Code 변경
+        try {
+            CreateUserResponseDto createUserResponseDto = userService.signUp(createUserRequestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(createUserResponseDto);
+        } catch (IllegalArgumentException e) { //서비스 단에서 IllegalArgumentException 예외 catch
+            if (e.getMessage().contains("해당 이메일이 이미 존재합니다.")) { //예외 메세지에 해당 내용이 존재하면 아래 에러 응답
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(
+                        Map.of("error", "Conflict",
+                                "message", e.getMessage())
+                );
+            } else { //존재하지 않으면 아래 에러 응답
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                        Map.of("error", "Bad Request",
+                                "message", "올바르지 않은 요청입니다.")
+                );
+            }
+        }
     }
+
+    //회원정보 조회
+    @GetMapping
+    public ResponseEntity<?> getUsers(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        //인증되지 않은 경우
+        if(userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body( //UNAUTHORIZED 상태 코드와 함게 아래 key value 형태로 body값 반환
+                    Map.of("error", "Unauthorized",
+                            "message", "인증 자격 증명이 제공되지 않았거나 유효하지 않습니다.")
+            );
+        }
+
+        try {
+            //userDetails에서 getUsername 메서드로 email을 꺼내서 서비스단에서 getUserByEmail 메서드로 유저 정보를 가져옴.
+            UserResponseDto userResponseDto = userService.getUserByEmail(userDetails.getUsername());
+            return ResponseEntity.ok(userResponseDto);
+        } catch (IllegalArgumentException e) {
+            //서비스 단에서 IllegalArgumentException 예외 catch
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    Map.of("error", "Not Found",
+                            "message", e.getMessage())
+            );
+        }
+    }
+
+    //닉네임 변경
+    @PatchMapping(value = "/nickname")
+    public ResponseEntity<?> updateNickname(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                            @Valid @RequestBody UpdateNicknameRequestDto updateNicknameRequestDto) {
+        if (userDetails == null) {
+            // 인증되지 않은 경우
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    Map.of("error", "Unauthorized",
+                            "message", "인증 자격 증명이 제공되지 않았거나 유효하지 않습니다.")
+            );
+        }
+
+        try {
+            userService.updateNickname(userDetails.getUsername(), updateNicknameRequestDto.getNickname());
+            return ResponseEntity.ok(Map.of("message", "닉네임이 성공적으로 변경되었습니다."));
+        } catch (IllegalArgumentException e) { //서비스 단에서 IllegalArgumentException 예외 catch
+            if (e.getMessage().contains("사용자가 존재하지 않습니다")) {  //예외 메세지에 해당 내용이 존재하면 아래 에러 응답
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                        Map.of("error", "Not Found",
+                                "message", e.getMessage())
+                );
+            } else { //존재하지 않으면 아래 에러 응답
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                        Map.of("error", "Bad Request",
+                                "message", "올바르지 않은 요청입니다.")
+                );
+            }
+        }
+    }
+
+    //비밀번호 변경
+    @PutMapping(value = "/pw")
+    public ResponseEntity<?> updatePassword(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                            @Valid @RequestBody UpdatePasswordRequestDto updatePasswordRequestDto) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    Map.of("error", "Unauthorized",
+                            "message", "인증 자격 증명이 제공되지 않았거나 유효하지 않습니다.")
+            );
+        }
+
+        try {
+            userService.updatePassword(userDetails.getUsername(), updatePasswordRequestDto.getNewPassword());
+            return ResponseEntity.ok(Map.of("message", "비밀번호가 성공적으로 재설정되었습니다."));
+        } catch (IllegalArgumentException e) { //서비스 단에서 IllegalArgumentException 예외 catch
+            if (e.getMessage().contains("요청한 사용자를 찾을 수 없습니다")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                        Map.of("error", "Not Found",
+                                "message", e.getMessage())
+                );
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                        Map.of("error", "Bad Request",
+                                "message", "올바르지 않은 요청입니다.")
+                );
+            }
+        }
+    }
+
+
+    //회원 탈퇴
+    @DeleteMapping
+    public ResponseEntity<?> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                    Map.of("error", "Unauthorized",
+                            "message", "인증 자격 증명이 제공되지 않았거나 유효하지 않습니다.")
+            );
+        }
+
+        try {
+            userService.deleteUser(userDetails.getUsername());
+            return ResponseEntity.ok(Map.of("message", "사용자가 성공적으로 삭제되었습니다"));
+        } catch (IllegalArgumentException e) { //서비스 단에서 IllegalArgumentException 예외 catch
+            if (e.getMessage().contains("요청한 사용자를 찾을 수 없습니다")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                        Map.of("error", "Not Found",
+                                "message", e.getMessage())
+                );
+            } else {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(
+                        Map.of("error", "Bad Request",
+                                "message", "올바르지 않은 요청입니다.")
+                );
+            }
+        }
+    }
+
 }
+
+

--- a/src/main/java/com/likelion/byuldajul/user/dto/CreateUserRequestDto.java
+++ b/src/main/java/com/likelion/byuldajul/user/dto/CreateUserRequestDto.java
@@ -24,7 +24,7 @@ public class CreateUserRequestDto {
     @NotBlank(message = "[ERROR] 비밀번호는 필수 입력값입니다.")
     private String password;
 
-    @Size(max = 12, message = "[ERROR] 닉네임은 12글자 이하여야 합니다.")
+    @Size(min = 1, max = 12, message = "[ERROR] 닉네임은 1자 이상, 12글자 이하여야 합니다.")
     @NotBlank(message = "[ERROR] 닉네임은 필수 입력값입니다.")
     private String nickname;
 

--- a/src/main/java/com/likelion/byuldajul/user/dto/UpdateNicknameRequestDto.java
+++ b/src/main/java/com/likelion/byuldajul/user/dto/UpdateNicknameRequestDto.java
@@ -1,0 +1,17 @@
+package com.likelion.byuldajul.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter //필드가 nickname 하나이므로 Builder 대신 Setter를 사용하였습니다.
+public class UpdateNicknameRequestDto {
+
+    @Size(min = 1, max = 12, message = "[ERROR] 닉네임은 1자 이상, 12글자 이하여야 합니다.")
+    @NotBlank(message = "[ERROR] 닉네임은 필수 입력값입니다.")
+    private String nickname;
+
+}

--- a/src/main/java/com/likelion/byuldajul/user/dto/UpdateNicknameRequestDto.java
+++ b/src/main/java/com/likelion/byuldajul/user/dto/UpdateNicknameRequestDto.java
@@ -2,16 +2,22 @@ package com.likelion.byuldajul.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.web.bind.annotation.BindParam;
 
 @Getter
-@Setter //필드가 nickname 하나이므로 Builder 대신 Setter를 사용하였습니다.
+@NoArgsConstructor
 public class UpdateNicknameRequestDto {
 
     @Size(min = 1, max = 12, message = "[ERROR] 닉네임은 1자 이상, 12글자 이하여야 합니다.")
     @NotBlank(message = "[ERROR] 닉네임은 필수 입력값입니다.")
     private String nickname;
 
+    @Builder
+    public UpdateNicknameRequestDto(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/likelion/byuldajul/user/dto/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/likelion/byuldajul/user/dto/UpdatePasswordRequestDto.java
@@ -3,11 +3,13 @@ package com.likelion.byuldajul.user.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter //필드가 newPassword 하나이므로 Builder 대신 Setter를 사용하였습니다.
+@NoArgsConstructor
 public class UpdatePasswordRequestDto {
 
     @Size(min = 8, max = 64, message = "[ERROR] 비밀번호는 8자 이상, 64자 이하여야 합니다.")
@@ -15,4 +17,8 @@ public class UpdatePasswordRequestDto {
     @NotBlank(message = "[ERROR] 비밀번호는 필수 입력값입니다.")
     private String newPassword;
 
+    @Builder
+    public UpdatePasswordRequestDto(String newPassword) {
+        this.newPassword = newPassword;
+    }
 }

--- a/src/main/java/com/likelion/byuldajul/user/dto/UpdatePasswordRequestDto.java
+++ b/src/main/java/com/likelion/byuldajul/user/dto/UpdatePasswordRequestDto.java
@@ -1,0 +1,18 @@
+package com.likelion.byuldajul.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter //필드가 newPassword 하나이므로 Builder 대신 Setter를 사용하였습니다.
+public class UpdatePasswordRequestDto {
+
+    @Size(min = 8, max = 64, message = "[ERROR] 비밀번호는 8자 이상, 64자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*\\d).{8,64}$", message = "[ERROR] 알파벳과 숫자가 모두 들어가는 8자리 이상의 비밀번호를 입력해주세요.")
+    @NotBlank(message = "[ERROR] 비밀번호는 필수 입력값입니다.")
+    private String newPassword;
+
+}

--- a/src/main/java/com/likelion/byuldajul/user/dto/UserResponseDto.java
+++ b/src/main/java/com/likelion/byuldajul/user/dto/UserResponseDto.java
@@ -1,0 +1,29 @@
+package com.likelion.byuldajul.user.dto;
+
+import com.likelion.byuldajul.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserResponseDto {
+
+    private String eamil;
+
+    private String nickname;
+
+    @Builder
+    public UserResponseDto(String eamil, String nickname) {
+        this.eamil = eamil;
+        this.nickname = nickname;
+    }
+
+    // Entity -> DTO 변환
+    public static UserResponseDto from(User user) {
+        return UserResponseDto.builder()
+                .eamil(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/likelion/byuldajul/user/entity/User.java
+++ b/src/main/java/com/likelion/byuldajul/user/entity/User.java
@@ -52,4 +52,14 @@ public class User {
     protected void onUpdate() {
         this.modifiedAt = LocalDateTime.now();
     }
+
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
 }

--- a/src/main/java/com/likelion/byuldajul/user/filter/JwtFilter.java
+++ b/src/main/java/com/likelion/byuldajul/user/filter/JwtFilter.java
@@ -1,10 +1,14 @@
 package com.likelion.byuldajul.user.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.byuldajul.exception.ErrorResponse;
 import com.likelion.byuldajul.user.entity.User;
 import com.likelion.byuldajul.user.repository.UserRepository;
 import com.likelion.byuldajul.user.userDetails.CustomUserDetails;
 import com.likelion.byuldajul.user.utils.JwtUtil;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,7 +48,7 @@ public class JwtFilter extends OncePerRequestFilter {
             if (accessToken == null) {
                 log.info("[ JwtAuthorizationFilter ] Access Token 이 존재하지 않음. 필터를 건너뜁니다.");
                 filterChain.doFilter(request, response);
-                return;
+                return; //이놈의 return을 빼먹어서!!!!!!!!! 새벽 3시까지!!!!! 하...어쩐지!!!!!!
             }
 
             authenticateAccessToken(accessToken);
@@ -52,9 +56,11 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
             log.warn("[ JwtAuthorizationFilter ] accessToken 이 만료되었습니다.");
-            response.setStatus(HttpStatus.UNAUTHORIZED.value()); // 401 return
-            response.setCharacterEncoding("UTF-8");
-            response.getWriter().write("Access Token 이 만료되었습니다.");
+            handleException(response, "Access Token 이 만료되었습니다.", HttpStatus.UNAUTHORIZED);
+        } catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            // 추가된 부분: 잘못된 토큰 예외 처리
+            log.warn("[ JwtAuthorizationFilter ] 잘못된 토큰입니다.");
+            handleException(response, "잘못된 토큰입니다.", HttpStatus.UNAUTHORIZED);
         }
     }
 
@@ -89,5 +95,14 @@ public class JwtFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authToken);
 
         log.info("[ JwtAuthorizationFilter ] 인증 객체 저장 완료");
+    }
+
+    // 예외를 처리하고 응답 본문을 설정하는 메서드
+    private void handleException(HttpServletResponse response, String message, HttpStatus status) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        ErrorResponse errorResponse = new ErrorResponse(status.getReasonPhrase(), message);
+        response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/com/likelion/byuldajul/user/service/UserService.java
+++ b/src/main/java/com/likelion/byuldajul/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.likelion.byuldajul.user.service;
 
 import com.likelion.byuldajul.user.dto.CreateUserRequestDto;
 import com.likelion.byuldajul.user.dto.CreateUserResponseDto;
+import com.likelion.byuldajul.user.dto.UserResponseDto;
 import com.likelion.byuldajul.user.entity.User;
 import com.likelion.byuldajul.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    //유저 생성(회원가입)
     @Transactional
     public CreateUserResponseDto signUp(CreateUserRequestDto createUserRequestDto) {
 
@@ -39,4 +41,51 @@ public class UserService {
         //DB에 저장한 Entity를 DTO로 변환 후 반환
         return CreateUserResponseDto.from(user);
     }
+
+    //유저 정보 조회
+    @Transactional(readOnly = true)
+    public UserResponseDto getUserByEmail(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("사용자가 존재히지 않습니다."));
+
+        log.info("[ User Service ] 사용자정보를 가져왔습니다.");
+        log.info("[ User Service ] 이메일 ---> {}", user.getEmail());
+        log.info("[ User Service ] 이름 ---> {}", user.getNickname());
+
+        //user 엔티티를 DTO로 변환 후 반
+        return UserResponseDto.from(user);
+    }
+
+    //유저 닉네임 변경
+    @Transactional
+    public void updateNickname(String email, String nickname) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("사용자가 존재히지 않습니다."));
+        user.setNickname(nickname);
+
+        log.info("[ User Service ] 이름이 변경되었습니다 ---> {}", user.getNickname());
+
+        userRepository.save(user);
+    }
+
+    //유저 비밀번호 변경
+    @Transactional
+    public void updatePassword(String email, String newPassword) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("요청한 사용자를 찾을 수 없습니다"));
+        user.setPassword(passwordEncoder.encode(newPassword));
+
+        log.info("[ User Service ] 비밀번호가 변경되었습니다 ---> {}", newPassword);
+
+        userRepository.save(user);
+    }
+
+    //유저 탈퇴
+    @Transactional
+    public void deleteUser(String email) {
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("요청한 사용자를 찾을 수 없습니다"));
+
+        log.info("[ User Service ] 사용자 탈퇴가 완료되었습니다 ---> {}", user.getEmail());
+
+        //refresh 토큰 삭제 로직은 로그아웃 기능 구현할 때 같이 할 예정
+        userRepository.delete(user);
+    }
+
 }


### PR DESCRIPTION
# ☝️Issue Number

- #8 

# 🔎 Key Changes
- **회원 정보 조회**
<img width="1492" alt="1" src="https://github.com/LikeLion12-Team3/Team3-Back/assets/86175262/bab986c2-34d1-4b8c-8d49-2b1d3735cb47">

---
- **닉네임 변경**
<img width="1480" alt="2" src="https://github.com/LikeLion12-Team3/Team3-Back/assets/86175262/9487bc68-cc2c-4d78-a51c-8877aed4ada0">

- DB
<img width="1053" alt="3" src="https://github.com/LikeLion12-Team3/Team3-Back/assets/86175262/a4bc22cb-793f-438d-a05b-b58164c9995f">

---
- **비밀번호 재설정**
<img width="1485" alt="4" src="https://github.com/LikeLion12-Team3/Team3-Back/assets/86175262/573109ef-3e04-4681-afd7-cb6f20cd2ce6">

- 로그
<img width="1255" alt="5" src="https://github.com/LikeLion12-Team3/Team3-Back/assets/86175262/3ae8c5ae-5fb4-4f3c-abb7-b397ea3993f4">

---
- **회원 탈퇴**
<img width="1491" alt="6" src="https://github.com/LikeLion12-Team3/Team3-Back/assets/86175262/1fa16fa4-b297-4bab-bc09-9823bbcc41ea">

- DB
<img width="1049" alt="7" src="https://github.com/LikeLion12-Team3/Team3-Back/assets/86175262/fe7fb20d-8ee3-4332-ab23-6f99089e6e39">

---
- **이미 있는 이메일로 회원가입**
<img width="1485" alt="8" src="https://github.com/LikeLion12-Team3/Team3-Back/assets/86175262/c6c051b0-2ef4-45ad-b3cd-24527ee2c357">


# 💌 To Reviewers
- 회원 탈퇴 시 Refresh 토큰 삭제는 로그아웃 기능 개발할 때 같이 진행하겠습니다!

+
컨트롤러 단에서 설정한 401 예외 처리는 JWT Filter에서 걸러지는 것 같습니다. 그래서 401 에러는 JWTFilter에서 처리하면 될 것 같다는 생각을 했습니다. 근데 400이랑 404 에러는 어떻게 처리하면 되는지 궁금합니다.
그래서 질문들을 정리 해보면
1. 401 에러는 JWTFilter에서 처리하면 되는 건지?
2. 만약 토큰이 정확하다면 조회, 탈퇴를 진행시키면 되지만, 토큰이 없거나 정확하지 않으면 404 에러가 아니라 401 에러가 뜰 텐데 그러면 결국 404 에러는 없어도 되지 않는가?
            2.1. 혼자 생각해본것 : 회원 탈퇴 시 액세스 토큰은 아직 유효하므로 남은 액세스 토큰의 만료 기간에 유저 조회같은 요청을 했을 때를 대비하는 것인가?
3. 추가로 400 에러는 올바르지 않은 요청 값을 주었을 때 받는 응답으로 알고 있는데 이미 DTO에서 validation 처리를 해주었기 때문에 400 에러를 받기 전에 DTO를 컨트롤러로 넘겨주는 부분에서 @Valid에 의해  에러 응답을 받는다. 그러면 400 에러는 어떤 상황에서 응답되는 건지?

글 읽어주셔서 감사합니당🙂‍↕️